### PR TITLE
Fix maxBuffer being exceeded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,13 +13,17 @@ program
   .version('1.0.0')
   .option('-c, --commits <n>', 'Number of commits to analyze', parseInt)
   .option('-p, --prefixes <l>', 'Conventional changelog prefixes used', parsePrefixes)
+  .option('-m, --maxBuffer [n]', 'Optional maxBuffer to be used in process. Defaults to 500KB. Increase if maxBuffer is exceeded', value => parseInt(value), 500)
   .parse(process.argv);
 
 if (program.commits && program.prefixes) {
   log({
     repo: process.cwd(),
     number: program.commits,
-    fields: ['authorDate', 'abbrevHash', 'hash', 'subject', 'authorName']
+    fields: ['authorDate', 'abbrevHash', 'hash', 'subject', 'authorName'],
+    execOptions: {
+      maxBuffer: 1024 * program.maxBuffer
+    }
   }, function(error, commits) {
     if (error) return console.log(colors.red(error));
 


### PR DESCRIPTION
Add `maxBuffer` as optional argument with a default of 500Kb, which is passed to the gitlog process.

Cool package 😄  I noticed that when running against one of my repos it was throwing `Error: stdout maxBuffer exceeded`. Since child process has a default maxBuffer of 200Kb ([docs](https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback)), I've added a `maxBuffer` optional argument with a default of 500Kb.